### PR TITLE
removed privmsg from milestone announcement check

### DIFF
--- a/plugins/crawl.js
+++ b/plugins/crawl.js
@@ -190,7 +190,7 @@ module.exports = {
     'player_milestone': function(milestone, privmsg, nick) {
       var self = this;
       this.bot.dispatch('check_watchlist', milestone.player, function(watched) {
-        if (watched || privmsg) self.bot.emit('say', false, milestone.text + ' (' + nick + ')');
+        if (watched) self.bot.emit('say', false, milestone.text + ' (' + nick + ')');
       });
       // TODO: check for ghost kills
     }


### PR DESCRIPTION
currently all privmsg were relayed. I don't think this is necessary for milestones where ONLY bots should be sending milestone info.
