### PR TITLE
Relay `.echo` commands to Sequell

### DIFF
--- a/plugins/crawl.js
+++ b/plugins/crawl.js
@@ -771,6 +771,12 @@ module.exports = {
         this.relay('Sequell', opt);
       }
     },
+    ".echo": {
+      description: "Echos back the argument, possibly including command line expansions.  See https://github.com/crawl/sequell/blob/master/docs/commandline.md for documentation.",
+      response: function(opt) {
+        this.relay('Sequell', opt);
+      }
+    },
 
     // Henzell
     "!dump": {


### PR DESCRIPTION
This is for command line expansions.  I just added this to the list with other commands, hopefully nothing extra needs to be done with the unusual "." prefix.  (advil)